### PR TITLE
Add tox-based CI test matrix, fix lint failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs tags for version
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-annex
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Install CI dependencies
+        run: pip install -e ".[ci]"
+
+      - name: Run tox
+        run: tox

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,8 @@ manual git init + git annex init:
 import asyncio
 import subprocess
 import sys
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands = pytest -m network {posargs:tests/}
 
 [testenv:cov]
 skip_install = false
-deps = .[test]
+deps = .[test,search]
 commands = pytest --cov=annextube --cov-report=html --cov-report=term {posargs:tests/}
 
 [testenv:full]


### PR DESCRIPTION
## Summary

- Fix ruff UP035 lint failure: import `Generator` from `collections.abc` instead of `typing` in `tests/conftest.py`
- Add `search` deps to tox `cov` environment to match default `testenv`
- Add `.github/workflows/test.yml` with tox-based Python 3.10-3.14 matrix using `tox-gh-actions`

## Details

The project had tox environments and a `[gh-actions]` mapping configured but no CI workflow to run them. This adds a minimal workflow that:
- Installs `git-annex` (needed by tests)
- Installs `.[ci]` extras (tox + tox-uv + tox-gh-actions)
- Runs `tox` which `tox-gh-actions` automatically scopes to the right envs per Python version

On Python 3.12: runs tests + lint + type + cov. On all other versions: runs tests only.

## Test plan

- [x] `tox -e lint` passes locally
- [x] `tox -e type` passes locally
- [x] `tox -e py3` passes locally (420 tests)
- [x] CI workflow runs successfully on the PR itself

Generated with [Claude Code](https://claude.ai/code)
